### PR TITLE
Fixes #4 zerologger bridge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/glenntam/ibtui
 
-go 1.23.5
+go 1.24.0
+
+toolchain go1.24.7
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.7
@@ -9,6 +11,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/scmhub/ibapi v0.10.39
 	github.com/scmhub/ibsync v0.10.39
+	golang.org/x/term v0.35.0
 )
 
 require (
@@ -29,7 +32,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robaho/fixed v0.0.0-20250130054609-fd0e46fcd988 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,10 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
-golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.35.0 h1:bZBVKBudEyhRcajGcNc3jIfWPqV4y/Kt2XcoigOWtDQ=
+golang.org/x/term v0.35.0/go.mod h1:TPGtkTLesOwf2DE8CgVYiZinHAOuy5AYUYT1lENIZnA=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/panels/panels.go
+++ b/internal/panels/panels.go
@@ -1,0 +1,56 @@
+// package panels contains the components for various different panels displayed.
+package panels
+
+import (
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	tabContentStyle = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).              // Full border around content
+		BorderForeground(lipgloss.Color("#7D56F4")).   // Purple border (matches active tab)
+		Padding(0, 1)                                 // 1 line vertical, 2 spaces horizontal padding
+		//MinHeight(15)                                  // Minimum height for content area
+	activeTabBorderStyle = lipgloss.NewStyle().
+		Bold(true).                                        // Make text bold
+		Foreground(lipgloss.Color("#FFFFFF")).            // White text
+		Background(lipgloss.Color("#7D56F4")).            // Purple background
+		Border(lipgloss.RoundedBorder(), true, true, false, true). // Border: top=yes, right=yes, bottom=NO, left=yes
+		BorderForeground(lipgloss.Color("#7D56F4")).       // Purple border color
+		Padding(0, 1)                                     // No vertical padding, 1 space horizontal
+
+	inactiveTabBorderStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#666666")).             // Gray text
+		Background(lipgloss.Color("#1A1A1A")).             // Dark background
+		Border(lipgloss.RoundedBorder(), true, true, false, true). // Same border pattern
+		BorderForeground(lipgloss.Color("#333333")).       // Dark gray border
+		Padding(0, 1)                                     // Same padding
+
+	statusStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#666666")).         // Gray color for status text
+		Italic(true)                                   // Make it italic
+)
+
+type PanelGroup struct {
+	Tabs      []string
+	Content   []string
+	ActiveTab int
+}
+
+func RenderPanelGroup(g *PanelGroup, width int) string {
+	var tabRow []string
+	for i, tab := range g.Tabs {
+		if i == g.ActiveTab {
+			tabRow = append(tabRow, activeTabBorderStyle.Render(tab))
+		} else {
+			tabRow = append(tabRow, inactiveTabBorderStyle.Render(tab))
+		}
+	}
+	tabBar := lipgloss.JoinHorizontal(lipgloss.Bottom, tabRow...)
+	body := tabContentStyle.
+		MaxHeight(12).
+		Width(width - 2).      // Account for border
+		Render(g.Content[g.ActiveTab]) // Show content for current tab
+	return lipgloss.JoinVertical(lipgloss.Left, tabBar, body)
+}
+

--- a/internal/state/IBstate.go
+++ b/internal/state/IBstate.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	// "fmt"
 	"log/slog"
 	"time"
 
@@ -37,10 +36,5 @@ func (s *IBState) ReqCurrentTimeMilli(ib *ibsync.IB, timezone string) {
 		nanoseconds := (m % 1000) * 1_000_000
 		t = time.Unix(seconds, nanoseconds)
 	}
-	tz, err := time.LoadLocation(timezone)
-	if err != nil {
-		slog.Error("Couldn't find "+timezone+" time zone.", "error", err)
-		tz = time.UTC
-	}
-	s.CurrentTime = t.In(tz)
+	s.CurrentTime = t
 }

--- a/internal/zerobridge/zerobridge.go
+++ b/internal/zerobridge/zerobridge.go
@@ -22,19 +22,13 @@ func (b *ZerologToSlogBridge) Write(p []byte) (n int, err error) {
 	// Extract standard fields
 	level, _ := logEntry["level"].(string)
 	message, _ := logEntry["message"].(string)
-	timestamp, _ := logEntry["time"].(string)
 
 	// Convert other fields to slog attributes
 	var attrs []slog.Attr
 	for k, v := range logEntry {
-		if k != "level" && k != "message" && k != "time" {
+		if k != "level" && k != "message" && k != "time" && k != "errorTime" {
 			attrs = append(attrs, slog.Any(k, v))
 		}
-	}
-
-	// Add timestamp if present
-	if timestamp != "" {
-		attrs = append(attrs, slog.String("zerolog_time", timestamp))
 	}
 
 	// Convert zerolog level to slog level and log


### PR DESCRIPTION
All zerologger logs from ibsync/ibapi now forward to ibtui's slog via a bridge.

Log timestamps (and ibapi/ibsync) now natively uses .env config setting by setting local system time accordingly.

Log panel display now correctly handles all word wraps in the logs given the terminal width.

All lipgloss styling moved to internal/panels package.

Use x/term at init time to set default screen width and height before bubbletea starts.
(Bumped to Go version 1.24 because x/term requires it)